### PR TITLE
Improving security of file uploads via Ajax and bringing the Upload File script up to WordPress coding standards

### DIFF
--- a/admin/library/options/options.php
+++ b/admin/library/options/options.php
@@ -375,7 +375,7 @@ function upfw_image($value,$attr){
                         var <?php echo $value['id']; ?>=jQuery('div.uploadify button#<?php echo $value['id']; ?>');
                         var status=jQuery('#<?php echo $value['id']; ?>status');
                         new AjaxUpload(<?php echo $value['id']; ?>, {
-                            action: '<?php echo THEME_DIR; ?>/admin/upload-file.php',
+							action: '<?php echo get_template_directory_uri(); ?>/admin/upload-file.php?_wp_upthemes_admin_upload_nonce=<?php echo wp_create_nonce( '_wp_upthemes_admin_upload_nonce' ) ?>',
                             name: '<?php echo $upload_security?>',
                             data: {
                             	upload_path : '<?php echo base64_encode(UPFW_UPLOADS_DIR); ?>'

--- a/admin/upload-file.php
+++ b/admin/upload-file.php
@@ -1,25 +1,34 @@
 <?php
 
-//Upload Security
-$upload_security = md5($_SERVER['SERVER_ADDR']);
+// Import WordPress headers to take advantage of the usual helper functions
+// This assumes this file is located in a typical /wp-conten/themes/ directory.
+include( '../../../../wp-blog-header.php' );
+
+// Upload Security
+$upload_security = md5( $_SERVER['SERVER_ADDR'] );
 $uploaddir = base64_decode( $_REQUEST['upload_path'] ) . "/";
 
-if( $_FILES[$upload_security] ):
+// If the current user is an administrator, the nonce generated on the front end is correct, and the $_FILES array is set with the security key, go for upload...
+if( current_user_can( 'upload_files' ) && wp_verify_nonce( $_GET['_wp_upthemes_admin_upload_nonce'], '_wp_upthemes_admin_upload_nonce' ) && isset( $_FILES[$upload_security] ) ) {
 
 	$file = $_FILES[$upload_security];
 
-	$file = $uploaddir . strtolower(str_replace('__', '_', str_replace('#', '_', str_replace(' ', '_', basename($file['name'])))));
+	$file = $uploaddir . strtolower( str_replace( '__', '_', str_replace( '#', '_', str_replace( ' ', '_', basename( $file['name'] ) ) ) ) );
 	
-		if (move_uploaded_file( $_FILES[$upload_security]['tmp_name'], $file)):
-			if(chmod($file,0777)):
+		if( move_uploaded_file( $_FILES[ $upload_security ]['tmp_name'], $file ) ) {
+		
+			if( chmod( $file, 0777 ) ) { 
 			    echo "success"; 
-			else:
-				echo "error".$_FILES[$upload_security]['tmp_name'];
-			endif;
-		else:
-		    echo "error".$_FILES[$upload_security]['tmp_name'];
-		endif;
+			} else {
+				echo "error" . $_FILES[ $upload_security]['tmp_name'];
+			} // end if/else
+			
+		} else {
+		    
+		    echo "error" . $_FILES[ $upload_security ]['tmp_name'];
+		    
+		} // end if
 
-endif;
+} // end if
 
 ?>


### PR DESCRIPTION
- Introducing a WordPress-generated nonce to the upload-file.php ajax call for file uploads. 
- Using `get_template_directory_uri()` rather than `THEME_DIR` when making the request to `upload-files.php`
- Updating `upload-file.php` to follow the [coding standards](http://codex.wordpress.org/WordPress_Coding_Standards)
- Verifying that the file uploads are performed by a user who can manage options (that is, an administrator)
- Verifying that the nonce is set and requested corresponds to the value generated by WordPress
- That the `$_FILES` security key is set

**Note**: This fix does assume that the file resides in a typical `/wp-content/themes/` directory (see the comment on lines 3 - 4 of `upload-file.php`)
