### PR TITLE
Adding Wordpress' Editor

### DIFF
--- a/library/options-register.php
+++ b/library/options-register.php
@@ -2,9 +2,9 @@
 /**
  * Theme Options Settings API
  *
- * This file implements the WordPress Settings API for the 
+ * This file implements the WordPress Settings API for the
  * Options for the UpThemes Framework.
- * 
+ *
  * @package 	UpThemes Framework
  * @copyright	Copyright (c) 2011, Chip Bennett
  * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
@@ -14,29 +14,29 @@
 
 /**
  * Register Theme Settings
- * 
+ *
  * Register theme options array to hold all theme options.
- * 
+ *
  * @link	http://codex.wordpress.org/Function_Reference/register_setting	Codex Reference: register_setting()
- * 
+ *
  * @param	string		$option_group		Unique Settings API identifier; passed to settings_fields() call
  * @param	string		$option_name		Name of the wp_options database table entry
  * @param	callback	$sanitize_callback	Name of the callback function in which user input data are sanitized
  */
-register_setting( 
+register_setting(
 	// $option_group
-	"theme_" . upfw_get_current_theme_id() . "_options", 
+	"theme_" . upfw_get_current_theme_id() . "_options",
 	// $option_name
-	"theme_" . upfw_get_current_theme_id() . "_options", 
+	"theme_" . upfw_get_current_theme_id() . "_options",
 	// $sanitize_callback
 	'upfw_options_validate'
 );
 
 /**
  * Register Global Admin Javascript Variables
- * 
+ *
  * Register JS variables used by theme options admin Javascript.
- * 
+ *
  * @global	array	Settings Page Tab definitions
  *
  */
@@ -44,7 +44,7 @@ register_setting(
 function upfw_register_admin_js_globals(){
 
 	global $up_tabs;
-	
+
 	$tab = '';
 	$selected_tab = '';
 
@@ -58,8 +58,8 @@ function upfw_register_admin_js_globals(){
 
 	if( isset( $_GET['page']) && esc_attr( $_GET['page'] ) == 'upfw-settings' && $selected_tab )
 		echo "    'current_tab' : '$selected_tab',\n";
-	
-	echo "    'theme_url' : '$theme_url'\n";	
+
+	echo "    'theme_url' : '$theme_url'\n";
 	echo "}" . "\n";
 	echo "</script>" . "\n";
 
@@ -70,14 +70,14 @@ add_action('admin_enqueue_scripts','upfw_register_admin_js_globals',1);
 
 /**
  * Theme register_setting() sanitize callback
- * 
- * Validate and whitelist user-input data before updating Theme 
+ *
+ * Validate and whitelist user-input data before updating Theme
  * Options in the database. Only whitelisted options are passed
  * back to the database, and user-input data for all whitelisted
  * options are sanitized.
- * 
+ *
  * @link	http://codex.wordpress.org/Data_Validation	Codex Reference: Data Validation
- * 
+ *
  * @param	array	$input	Raw user-input data submitted via the Theme Settings page
  * @return	array	$input	Sanitized user-input data passed to the database
  *
@@ -97,18 +97,18 @@ function upfw_options_validate( $input ) {
 	// Get the array of option defaults
 	$option_defaults = upfw_get_option_defaults();
 	// Get list of tabs
-	
+
 	// Determine what type of submit was input
-	$submittype = 'submit';	
+	$submittype = 'submit';
 	foreach ( $up_tabs as $tab ) {
 		$resetname = 'reset-' . $tab['name'];
 		if ( ! empty( $input[$resetname] ) ) {
 			$submittype = 'reset';
 		}
 	}
-	
+
 	// Determine what tab was input
-	$submittab = '';	
+	$submittab = '';
 	foreach ( $up_tabs as $tab ) {
 		$submitname = 'submit-' . $tab['name'];
 		$resetname = 'reset-' . $tab['name'];
@@ -121,18 +121,18 @@ function upfw_options_validate( $input ) {
 
 	// Loop through each tab setting
 	foreach ( $tabsettings as $setting ) {
-					
+
 		// If no option is selected, set the default
 		$valid_input[$setting] = ( ! isset( $input[$setting] ) ? $option_defaults[$setting] : $input[$setting] );
 
 		// If submit, validate/sanitize $input
 		if ( 'submit' == $submittype ) {
-		
+
 			// Get the setting details from the defaults array
 			$optiondetails = $option_parameters[$setting];
 			// Get the array of valid options, if applicable
 			$valid_options = ( isset( $optiondetails['valid_options'] ) ? $optiondetails['valid_options'] : false );
-			
+
 			// Validate checkbox fields
 			if ( 'checkbox' == $optiondetails['type'] ) {
 				// If input value is set and is true, return true; otherwise return false
@@ -171,7 +171,7 @@ function upfw_options_validate( $input ) {
 					$valid_input[$setting] = wp_filter_kses( $input[$setting] );
 				}
 			}
-		} 
+		}
 		// If reset, reset defaults
 		elseif ( 'reset' == $submittype ) {
 			// Set $setting to the default value
@@ -183,22 +183,22 @@ function upfw_options_validate( $input ) {
 }
 
 /**
- * Globalize the variable that holds 
+ * Globalize the variable that holds
  * the Settings Page tab definitions
- * 
+ *
  * @global	array	Settings Page Tab definitions
  */
 global $up_tabs;
 
 /**
- * Call add_settings_section() for each Settings 
- * 
- * Loop through each Theme Settings page tab, and add 
- * a new section to the Theme Settings page for each 
+ * Call add_settings_section() for each Settings
+ *
+ * Loop through each Theme Settings page tab, and add
+ * a new section to the Theme Settings page for each
  * section specified for each tab.
- * 
+ *
  * @link	http://codex.wordpress.org/Function_Reference/add_settings_section	Codex Reference: add_settings_section()
- * 
+ *
  * @param	string		$sectionid	Unique Settings API identifier; passed to add_settings_field() call
  * @param	string		$title		Title of the Settings page section
  * @param	callback	$callback	Name of the callback function in which section text is output
@@ -210,7 +210,7 @@ foreach ( $up_tabs as $tab ) {
 	foreach ( $tabsections as $section ) {
 		$sectionname = $section['name'];
 		$sectiontitle = $section['title'];
-		
+
 		// Add settings section
 		add_settings_section(
 			// $sectionid
@@ -228,10 +228,10 @@ foreach ( $up_tabs as $tab ) {
 
 /**
  * Callback for add_settings_section()
- * 
+ *
  * Generic callback to output the section text
- * for each Plugin settings section. 
- * 
+ * for each Plugin settings section.
+ *
  * @param	array	$section_passed	Array passed from add_settings_section()
  */
 function upfw_sections_callback( $section_passed ) {
@@ -249,9 +249,9 @@ function upfw_sections_callback( $section_passed ) {
 }
 
 /**
- * Globalize the variable that holds 
+ * Globalize the variable that holds
  * all the Theme option parameters
- * 
+ *
  * @global	array	Theme options parameters
  */
 global $option_parameters;
@@ -259,13 +259,13 @@ $option_parameters = upfw_get_option_parameters();
 
 /**
  * Call add_settings_field() for each Setting Field
- * 
- * Loop through each Theme option, and add a new 
- * setting field to the Theme Settings page for each 
+ *
+ * Loop through each Theme option, and add a new
+ * setting field to the Theme Settings page for each
  * setting.
- * 
+ *
  * @link	http://codex.wordpress.org/Function_Reference/add_settings_field	Codex Reference: add_settings_field()
- * 
+ *
  * @param	string		$settingid	Unique Settings API identifier; passed to the callback function
  * @param	string		$title		Title of the setting field
  * @param	callback	$callback	Name of the callback function in which setting field markup is output
@@ -310,62 +310,66 @@ function upfw_setting_callback( $option ) {
 
 	$attr = $option_parameters[$option['name']];
 	$value = $upfw_options[$optionname];
-	
+
     //Determine the type of input field
     switch ( $fieldtype ) {
-        
+
         //Render Text Input
         case 'text': upfw_text_field($value,$attr);
         break;
-        
+
         //Render Custom User Text Inputs
         case 'text_list': upfw_text_list($value,$attr);
         break;
-        
+
         //Render textarea options
         case 'textarea': upfw_textarea($value,$attr);
         break;
-                
+
+        //Render wordpress editor options
+        case 'editor': upfw_editor($value,$attr);
+        break;
+
         //Render select dropdowns
         case 'select': upfw_select($value,$attr);
         break;
-        
+
         //Render radio image dropdowns
         case 'radio': upfw_radio($value,$attr);
         break;
-                
+
         //Render radio image dropdowns
         case 'radio_image': upfw_radio_image($value,$attr);
         break;
-        
+
         //Render multple selects
         case 'multiple': upfw_multiple($value,$attr);
         break;
-    
+
         //Render checkboxes
         case 'checkbox': upfw_checkbox($value,$attr);
         break;
-        
+
         //Render color picker
         case 'color': upfw_color($value,$attr);
         break;
-        
+
         //Render upload image
         case 'image': upfw_image($value,$attr);
         break;
-        
+
         //Render category dropdown
         case 'category': upfw_category($value,$attr);
         break;
-        
+
         //Render categories multiple select
         case 'categories': upfw_categories($value,$attr);
         break;
-        
+
         //Render page dropdown
         case 'page': upfw_page($value,$attr);
         break;
-        
+
         //Render pages muliple select
         case 'pages': upfw_pages($value,$attr);
         break;
@@ -376,7 +380,7 @@ function upfw_setting_callback( $option ) {
 
 	    default:
 	    break;
-	    
+
 	}
 
 }

--- a/options.php
+++ b/options.php
@@ -25,18 +25,18 @@ function register_theme_option_tab( $args ){
 
 /**
  * Define Theme Title Constant
- * 
+ *
  * Set up the constant named THEME_TITLE
- * 
+ *
  * @link	http://codex.wordpress.org/Function_Reference/register_setting	Codex Reference: register_setting()
- * 
+ *
  * @uses  wp_get_theme()            http://codex.wordpress.org/Function_Reference/wp_get_theme	Codex Reference: wp_get_theme()
  * @uses  get_template_directory()  http://codex.wordpress.org/Function_Reference/get_template_directory	Codex Reference: get_template_directory()
  * @param	array		$themedata		    Holds the theme object
  * @param	string	$theme_title	    Name of the current theme
  */
 function upfw_define_theme_title(){
-  
+
   if( function_exists('wp_get_theme') ):
     $themedata = wp_get_theme();
     $theme_title = $themedata->title;
@@ -54,9 +54,9 @@ add_action('after_setup_theme','upfw_define_theme_title');
 
 /**
  * Return current theme ID
- * 
+ *
  * Checks theme data for theme ID and returns it
- * 
+ *
  * @uses  wp_get_theme()              http://codex.wordpress.org/Function_Reference/wp_get_theme	Codex Reference: wp_get_theme()
  * @uses  get_template_directory()    http://codex.wordpress.org/Function_Reference/get_template_directory	Codex Reference: get_template_directory()
  * @param	array		$themedata		      Holds the theme object
@@ -75,7 +75,7 @@ function upfw_get_current_theme_id(){
 	endif;
 
 	$theme_shortname = strtolower(preg_replace('/ /', '_', $theme_title));
-	
+
 	return $theme_shortname;
 
 }
@@ -130,14 +130,14 @@ add_action('admin_print_scripts-appearance_page_upfw-settings','upfw_enqueue_scr
  * UpThemes Framework Theme Options
  *
  * This file defines the Options for the UpThemes Framework.
- * 
+ *
  * Theme Options Functions
- * 
+ *
  *  - Define Default Theme Options
  *  - Register/Initialize Theme Options
  *  - Define Admin Settings Page
  *  - Register Contextual Help
- * 
+ *
  * @package 	UpThemes Framework
  * @copyright	Copyright (c) 2011, Chip Bennett
  * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License, v2 (or newer)
@@ -147,16 +147,16 @@ add_action('admin_print_scripts-appearance_page_upfw-settings','upfw_enqueue_scr
 
 /**
  * Globalize the variable that holds the Theme Options
- * 
+ *
  * @global	array	$up_theme_options	holds Theme options
  */
 global $up_theme_options;
 /**
  * upfw Theme Settings API Implementation
  *
- * Implement the WordPress Settings API for the 
+ * Implement the WordPress Settings API for the
  * upfw Theme Settings.
- * 
+ *
  * @link	http://codex.wordpress.org/Settings_API	Codex Reference: Settings API
  * @link	http://ottopress.com/2009/wordpress-settings-api-tutorial/	Otto
  * @link	http://planetozh.com/blog/2009/05/handling-plugins-options-in-wordpress-28-with-register_setting/	Ozh
@@ -170,9 +170,9 @@ add_action( 'admin_init', 'upfw_register_options' );
 
 /**
  * Setup the Theme Admin Settings Page
- * 
+ *
  * Add "upfw Options" link to the "Appearance" menu
- * 
+ *
  * @uses	upfw_get_settings_page_cap()	defined in \functions\wordpress-hooks.php
  */
 function upfw_add_theme_page() {
@@ -182,16 +182,16 @@ function upfw_add_theme_page() {
 	$upfw_settings_page = add_theme_page(
 		// $page_title
 		// Name displayed in HTML title tag
-		__( 'Theme Options', 'upfw' ), 
+		__( 'Theme Options', 'upfw' ),
 		// $menu_title
 		// Name displayed in the Admin Menu
-		__( 'Theme Options', 'upfw' ), 
+		__( 'Theme Options', 'upfw' ),
 		// $capability
 		// User capability required to access page
-		upfw_get_settings_page_cap(), 
+		upfw_get_settings_page_cap(),
 		// $menu_slug
 		// String to append to URL after "themes.php"
-		'upfw-settings', 
+		'upfw-settings',
 		// $callback
 		// Function to define settings page markup
 		'upfw_admin_options_page'
@@ -202,7 +202,7 @@ add_action( 'admin_menu', 'upfw_add_theme_page' );
 
 /**
  * upfw Theme Settings Page Markup
- * 
+ *
  * @uses	upfw_get_current_tab()	defined in \library\custom.php
  * @uses	upfw_get_page_tab_markup()	defined in \library\custom.php
  */
@@ -222,7 +222,7 @@ function upfw_admin_options_page() {
 				echo '</p></div>';
 		} ?>
 		<form action="options.php" method="post">
-		<?php 
+		<?php
 			// Implement settings field security, nonces, etc.
 			settings_fields("theme_" . ( upfw_get_current_theme_id() ) . "_options");
 			// Output each settings section, and each
@@ -233,18 +233,18 @@ function upfw_admin_options_page() {
 			<?php submit_button( __( 'Reset Defaults', 'upfw' ), 'secondary', "theme_" . ( upfw_get_current_theme_id() ) . "_options[reset-{$currenttab}]", false ); ?>
 		</form>
 	</div>
-<?php 
+<?php
 }
 
 /**
  * upfw Theme Option Defaults
- * 
- * Returns an associative array that holds 
- * all of the default values for all Theme 
+ *
+ * Returns an associative array that holds
+ * all of the default values for all Theme
  * options.
- * 
+ *
  * @uses	upfw_get_option_parameters()	defined in \functions\options.php
- * 
+ *
  * @return	array	$defaults	associative array of option defaults
  */
 function upfw_get_option_defaults() {
@@ -271,13 +271,13 @@ function upfw_get_option_defaults() {
 
 /**
  * upfw Theme Option Default
- * 
- * Returns an associative array that holds 
- * all of the default values for all Theme 
+ *
+ * Returns an associative array that holds
+ * all of the default values for all Theme
  * options.
- * 
+ *
  * @uses	upfw_get_option_parameters()	defined in \functions\options.php
- * 
+ *
  * @return	string	$default single default value
  */
 function upfw_get_option_default($name) {
@@ -298,7 +298,7 @@ function upfw_get_option_default($name) {
 
 /**
  * upfw Theme Option Parameters
- * 
+ *
  * Array that holds parameters for all options for
  * upfw. The 'type' key is used to generate
  * the proper form field markup and to sanitize
@@ -307,7 +307,7 @@ function upfw_get_option_default($name) {
  * option appears, and the 'section' tab determines
  * the section of the Settings Page tab in which
  * the option appears.
- * 
+ *
  * @return	array	$options	array of arrays of option parameters
  */
 function upfw_get_option_parameters() {
@@ -317,7 +317,7 @@ function upfw_get_option_parameters() {
 
 /**
  * upfw Migrate Theme Options
- * 
+ *
  * For users who are upgrading from an older theme
  * that uses the UpThemes Framework, this function
  * checks for the existence of the old theme option
@@ -328,25 +328,25 @@ function upfw_get_option_parameters() {
 function upfw_migrate_theme_options(){
 
 	if( is_admin() && isset($_GET['activated'] ) && $pagenow == 'themes.php' ):
-	
+
 		$theme_key = "theme_" . upfw_get_current_theme_id() . "_options";
-	
+
 		$old_upfw_options = get_option("up_themes_".UPTHEMES_SHORT_NAME);
 		$new_upfw_options = get_option($theme_key);
-		
+
 		if( $old_upfw_options === false )
 			return;
-		 
+
 		if( !$new_upfw_options && $old_upfw_options ):
-			
+
 			if( !update_option($theme_key, $old_upfw_options) )
 				wp_die( __("Could not update theme options.","upfw") );
-			
+
 			if( get_option($theme_key) === $old_upfw_options )
 				delete_option("up_themes_".UPTHEMES_SHORT_NAME);
 
 		endif;
-	
+
 	endif;
 
 }
@@ -355,18 +355,18 @@ add_action('switch_themes','upfw_migrate_theme_options');
 
 /**
  * Get upfw Theme Options
- * 
+ *
  * Array that holds all of the defined values
- * for upfw Theme options. If the user 
- * has not specified a value for a given Theme 
+ * for upfw Theme options. If the user
+ * has not specified a value for a given Theme
  * option, then the option's default value is
  * used instead.
  *
  * @uses	upfw_get_option_defaults()	defined in \functions\options.php
- * 
+ *
  * @uses	get_option()
  * @uses	wp_parse_args()
- * 
+ *
  * @return	array	$upfw_options	current values for all Theme options
  */
 function upfw_get_options() {
@@ -382,13 +382,13 @@ function upfw_get_options() {
 
 /**
  * Separate settings by tab
- * 
+ *
  * Returns an array of tabs, each of
  * which is an indexed array of settings
  * included with the specified tab.
  *
  * @uses	upfw_get_option_parameters()	defined in \functions\options.php
- * 
+ *
  * @return	array	$settingsbytab	array of arrays of settings by tab
  */
 function upfw_get_settings_by_tab() {
@@ -402,7 +402,7 @@ function upfw_get_settings_by_tab() {
 	foreach ( $up_tabs as $tab ) {
 		$tabname = $tab['name'];
 		// Add an indexed array key
-		// to the settings-by-tab 
+		// to the settings-by-tab
 		// array for each tab name
 		$tabs[] = $tabname;
 	}
@@ -415,7 +415,7 @@ function upfw_get_settings_by_tab() {
 		if ( in_array( $option_parameter['tab'] , $tabs ) ) {
 			$optiontab = $option_parameter['tab'];
 			$optionname = $option_parameter['name'];
-			// Add an indexed array key to the 
+			// Add an indexed array key to the
 			// settings-by-tab array for each
 			// setting associated with each tab
 			$settingsbytab[$optiontab][] = $optionname;
@@ -436,7 +436,7 @@ add_action( 'option_page_capability_upfw-settings', 'upfw_get_settings_page_cap'
 function upfw_text_field($value,$attr){ ?>
 
 	<input type="text" name="theme_<?php echo upfw_get_current_theme_id(); ?>_options[<?php echo $attr['name']; ?>]" value="<?php echo $value; ?>">
-                
+
 <?php
 }
 
@@ -472,7 +472,7 @@ function upfw_text_list($value,$attr){ ?>
                 endif;
             endif;
         endif;?>
-        
+
     </div>
 
 	<?php $add_text = __('Add New Field', 'upfw');?>
@@ -486,15 +486,30 @@ function upfw_textarea($value,$attr){ ?>
 <?php
 }
 
+function upfw_editor($value, $attr) {
+    // setup some basic variables to help
+    $theme_id = upfw_get_current_theme_id();
+    $name = $attr['name'];
+
+    // remap some of the $attr keys to wp_editor keys
+    // more settings can be remapped once they are needed
+    $editor_settings = array(
+        'textarea_name' => "theme_{$theme_id}_options[{$name}]"
+    );
+
+    // WordPress Editor generator
+    wp_editor($value, $attr['id'], $editor_settings);
+}
+
 function upfw_select($value,$attr){ ?>
 <select name="theme_<?php echo upfw_get_current_theme_id(); ?>_options[<?php echo $attr['name']; ?>]">
     <?php
     if ( isset( $attr['valid_options'] ) ) :
         $options = $attr['valid_options'];
-        foreach( $options as $option ) : 
+        foreach( $options as $option ) :
         ?>
             <option value="<?php echo $option['name']; ?>" <?php selected($option['name'],$value); ?>><?php echo $option['title']; ?></option>
-			<?php 
+			<?php
 		endforeach;
 	else:
 		_e("This option has no valid options. Please create valid options as an array inside the UpThemes Framework.","upfw");
@@ -508,7 +523,7 @@ function upfw_radio_image($value,$attr){ ?>
     <?php
     if ( isset( $attr['valid_options'] ) ) :
         $options = $attr['valid_options'];
-        foreach( $options as $option ) : 
+        foreach( $options as $option ) :
         ?>
     <label class="radio_image">
     <input type="radio" name="theme_<?php echo upfw_get_current_theme_id(); ?>_options[<?php echo $attr['name']; ?>]" value="<?php echo $option['name']; ?>" <?php checked($option['name'],$value); ?>>
@@ -528,7 +543,7 @@ function upfw_radio($value,$attr){ ?>
     <?php
     if ( isset( $attr['valid_options'] ) ) :
         $options = $attr['valid_options'];
-        foreach( $options as $option ) : 
+        foreach( $options as $option ) :
         ?>
     <label class="radio">
       <input type="radio" name="theme_<?php echo upfw_get_current_theme_id(); ?>_options[<?php echo $attr['name']; ?>]" value="<?php echo $option['name']; ?>" <?php checked($option['name'],$value); ?>> <?php echo $option['title']; ?>
@@ -628,7 +643,7 @@ function upfw_categories($value,$attr){
     endforeach;
     ?>
 </select>
-                
+
 <?php
 }
 
@@ -654,7 +669,7 @@ function upfw_page($value,$attr){
 	    endforeach;
 	    ?>
 	</select>
-                
+
 <?php
 }
 


### PR DESCRIPTION
I have added the WordPress Editor to the list of available field types to choose from. This has been tested on 3.5 and 3.5.1 which I saw that you required this now anyway because of the color picker so this should be good to go!

It enables basic settings right now with the name and id changeable.

This could be extended to enabled a simple `array_merge()` with the `$attr` argument into the settings argument in wp_editor to allow custom settings passed directly in.
