### PR TITLE
Updated the documentation link in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 To get started using the framework, you simply need your own WordPress theme.
 
-Read the documentation for more details: [UpThemes Framework Documentation](http://liftux.github.com/UpThemes-Framework/)
+Read the documentation for more details: [UpThemes Framework Documentation](https://upthemes.com/upthemes-framework/documentation/)


### PR DESCRIPTION
The current readme file links to: http://liftux.github.com/UpThemes-Framework/ which returns a 404.

I've changed the link to: https://upthemes.com/upthemes-framework/documentation/
