### PR TITLE
Update options.php

### DIFF
--- a/options.php
+++ b/options.php
@@ -122,8 +122,9 @@ function upfw_get_theme_options_directory() {
 
 function upfw_get_theme_dir(){
 	$theme = wp_get_theme();
-
-	if( ! empty( $theme->get('Template') ) ){
+	
+	$theme_template = $theme->get('Template');
+	if( ! empty( $theme_template ) ){
 		return get_stylesheet_directory_uri();
 	}
 


### PR DESCRIPTION
Fix to below error:
Fatal error: Can't use method return value in write context in D:\wamp\www\wp\wp-content\themes\upthemes-test\lib\UpThemes-Framework\options.php on line 126
